### PR TITLE
Fix cronjob api version to be compatible with k8s 1.20.13

### DIFF
--- a/kubernetes/cray-baremetal-etcd-backup/Chart.yaml
+++ b/kubernetes/cray-baremetal-etcd-backup/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: cray-baremetal-etcd-backup
-version: 0.2.0
+version: 0.2.1
 description: Backs up the Kubernetes etcd cluster
 home: https://github.com/Cray-HPE/cray-baremetal-etcd-backup
 maintainers:

--- a/kubernetes/cray-baremetal-etcd-backup/templates/cronjob.yaml
+++ b/kubernetes/cray-baremetal-etcd-backup/templates/cronjob.yaml
@@ -1,6 +1,6 @@
 # Copyright 2021 Hewlett Packard Enterprise Development LP
 ---
-apiVersion: batch/v1
+apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
   name: {{ include "cray-baremetal-etcd-backup.fullname" . }}


### PR DESCRIPTION
## Summary and Scope

Part of the CASM-2670 refactoring prematurely changed the cronjob api version to batch/v1 -- we'll have to hold on that till we're running a later version of K8S.

## Issues and Related PRs

* Resolves [CASMINST-3694](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-3694)

## Testing

vshasta:

```
ncn-m001-72c7d5a2:/home/bklein # kubectl -n kube-system get cronjob.batch/kube-etcdbackup -o yaml | head -2l
apiVersion: batch/v1beta1
kind: CronJob
```

### Tested on:

  * `vshasta`

### Test description:

Deployed chart in vshasta, cronjob was created with old api version

## Risks and Mitigations

Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

