### PR TITLE
Use locally built image, prevent slew of error'd pods if jobs failing (CASMPET-6676)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,11 @@ NAME ?= cray-baremetal-etcd-backup
 
 CHARTDIR ?= kubernetes
 
+CHART_METADATA_IMAGE ?= artifactory.algol60.net/csm-docker/stable/chart-metadata
 YQ_IMAGE ?= artifactory.algol60.net/docker.io/mikefarah/yq:4
-HELM_IMAGE ?= artifactory.algol60.net/docker.io/alpine/helm:3.7.1
-HELM_UNITTEST_IMAGE ?= artifactory.algol60.net/docker.io/quintush/helm-unittest
-HELM_DOCS_IMAGE ?= artifactory.algol60.net/docker.io/jnorwood/helm-docs:v1.5.0
+HELM_IMAGE ?= artifactory.algol60.net/csm-docker/stable/docker.io/alpine/helm:3.9.4
+HELM_UNITTEST_IMAGE ?= artifactory.algol60.net/csm-docker/stable/docker.io/quintush/helm-unittest:latest
+HELM_DOCS_IMAGE ?= artifactory.algol60.net/csm-docker/stable/docker.io/jnorwood/helm-docs:v1.5.0
 
 all: package test
 
@@ -29,7 +30,11 @@ ${CHARTDIR}/.packaged:
 
 test:
 	CMD="lint ${CHARTDIR}/${NAME}" $(MAKE) helm
-	docker run --rm -v ${PWD}/${CHARTDIR}:/apps ${HELM_UNITTEST_IMAGE} -3 ${NAME}
+	docker run --rm \
+		--user $(shell id -u):$(shell id -g) \
+		-v ${PWD}/${CHARTDIR}:/apps \
+		${HELM_UNITTEST_IMAGE} \
+		${NAME}
 
 extract-images:
 	{ CMD="template release ${CHARTDIR}/${NAME} --dry-run --replace --dependency-update" $(MAKE) -s helm; \

--- a/kubernetes/cray-baremetal-etcd-backup/Chart.yaml
+++ b/kubernetes/cray-baremetal-etcd-backup/Chart.yaml
@@ -1,13 +1,13 @@
 apiVersion: v2
 name: cray-baremetal-etcd-backup
-version: 0.2.1
+version: 0.2.2
 description: Backs up the Kubernetes etcd cluster
 home: https://github.com/Cray-HPE/cray-baremetal-etcd-backup
 maintainers:
-  - name: brantk-hpe
-appVersion: latest
+  - name: bklein
+appVersion: v0.1.0
 annotations:
   artifacthub.io/images: |
     - name: kube-etcdbackup
-      image: artifactory.algol60.net/csm-docker/stable/docker.io/roffe/kube-etcdbackup:latest
+      image: artifactory.algol60.net/csm-docker/stable/docker.io/roffe/kube-etcdbackup:v0.1.0
   artifacthub.io/license: MIT

--- a/kubernetes/cray-baremetal-etcd-backup/templates/cronjob.yaml
+++ b/kubernetes/cray-baremetal-etcd-backup/templates/cronjob.yaml
@@ -13,12 +13,14 @@ spec:
   jobTemplate:
     spec:
       backoffLimit: 1
+      activeDeadlineSeconds: {{ .Values.jobActiveDeadlineSeconds }}
       template:
         metadata:
           labels:
             {{- include "cray-baremetal-etcd-backup.selectorLabels" . | nindent 12 }}
         spec:
           restartPolicy: Never
+          activeDeadlineSeconds: {{ .Values.podActiveDeadlineSeconds }}
           containers:
           - name: {{ include "cray-baremetal-etcd-backup.name" . }}
             securityContext:

--- a/kubernetes/cray-baremetal-etcd-backup/values.yaml
+++ b/kubernetes/cray-baremetal-etcd-backup/values.yaml
@@ -5,8 +5,8 @@ fullnameOverride: kube-etcdbackup
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/docker.io/roffe/kube-etcdbackup
-  tag: latest
-  pullPolicy: Always
+  tag: v0.1.0
+  pullPolicy: IfNotPresent
 
 imagePullSecrets: []
 
@@ -14,7 +14,17 @@ schedule: '*/10 * * * *'
 
 successfulJobsHistoryLimit: 1
 failedJobsHistoryLimit: 1
-
+#
+# Settings below are meant to prevent multiple
+# pods in error state from overwhelming the system.
+#
+# To allow the job pod to be scheduled, we must set activeDeadlineSeconds in
+# two places, and set the Pod's .spec.activeDeadlineSeconds
+# to a higher value than the Job's .spec.activeDeadlineSeconds
+# in order to prevent the pod from being killed prematurely.
+#
+jobActiveDeadlineSeconds: 300
+podActiveDeadlineSeconds: 330
 securityContext: {}
   # capabilities:
   #   drop:


### PR DESCRIPTION
### Summary and Scope

Use locally built image, change cronjob to not ddos with tons of error pods if backups fail.

### Issues and Related PRs

* https://jira-pro.it.hpe.com:8443/browse/CASMPET-6676

### Testing

ashton (before with config error):

```
pod/kube-etcdbackup-28149980-zs4jm     0/1     Completed                    0               34m
pod/kube-etcdbackup-28149990-rgl2m     0/1     CreateContainerConfigError   0               24m
pod/kube-etcdbackup-28150000-r4rjj     0/1     CreateContainerConfigError   0               14m
pod/kube-etcdbackup-28150008-h8vp4     0/1     CreateContainerConfigError   0               6m34s
pod/kube-etcdbackup-28150009-fjt4m     0/1     CreateContainerConfigError   0               5m34s
pod/kube-etcdbackup-28150010-2j6h8     0/1     CreateContainerConfigError   0               4m34s
pod/kube-etcdbackup-28150011-jmz9p     0/1     CreateContainerConfigError   0               3m34s
pod/kube-etcdbackup-28150012-fhr4p     0/1     CreateContainerConfigError   0               2m34s
pod/kube-etcdbackup-28150013-pnt7w     0/1     CreateContainerConfigError   0               94s
pod/kube-etcdbackup-28150014-47hrv     0/1     CreateContainerConfigError   0               34s
job.batch/kube-etcdbackup-28149980   1/1           14s        34m
job.batch/kube-etcdbackup-28149990   0/1           24m        24m
job.batch/kube-etcdbackup-28150000   0/1           14m        14m
job.batch/kube-etcdbackup-28150008   0/1           6m34s      6m34s
job.batch/kube-etcdbackup-28150009   0/1           5m34s      5m34s
job.batch/kube-etcdbackup-28150010   0/1           4m34s      4m34s
job.batch/kube-etcdbackup-28150011   0/1           3m34s      3m34s
job.batch/kube-etcdbackup-28150012   0/1           2m34s      2m34s
job.batch/kube-etcdbackup-28150013   0/1           94s        94s
job.batch/kube-etcdbackup-28150014   0/1           34s        34s
```

ashton (after with config error):

```
pod/kube-etcdbackup-28150099-25vlm     0/1     Completed                    0               3m13s
pod/kube-etcdbackup-28150102-vqdcl     0/1     CreateContainerConfigError   0               13s
job.batch/kube-etcdbackup-28150099   1/1           13s        3m13s
job.batch/kube-etcdbackup-28150101   0/1           73s        73s
job.batch/kube-etcdbackup-28150102   0/1           13s        13s
```

ashton (after recovered from config error):

```
pod/kube-etcdbackup-28150105-nqlx2     0/1     Completed   0               23s
job.batch/kube-etcdbackup-28150103   0/1           2m23s      2m23s
job.batch/kube-etcdbackup-28150105   1/1           13s        23s
```

Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing
